### PR TITLE
Fix periodType pattern

### DIFF
--- a/src/main/resources/xsd/price_list.xsd
+++ b/src/main/resources/xsd/price_list.xsd
@@ -105,7 +105,7 @@
 
 	<simpleType name="periodType">
 		<restriction base="string">
-			<pattern value="[1-9]{1,2}[d,m,q,y]{1}" />
+			<pattern value="[0-9]{1,2}[dmqy]{1}" />
 		</restriction>
 	</simpleType>
 


### PR DESCRIPTION
Allow 0 in the character class for period values. Needed for create period of tm-tld.
Fix syntax of the character class for period units. As of now, commas are valid characters, so '12,' would qualify as a correct period.